### PR TITLE
feat(cache): introduce cache component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,16 @@
         "azjezz/psl": "2.0.x-dev"
     },
     "require-dev": {
+        "amphp/cache": "v2.x-dev",
         "friendsofphp/php-cs-fixer": "^3.4.0",
         "php-coveralls/php-coveralls": "^2.5",
         "phpunit/phpunit": "^9.5.10",
-        "squizlabs/php_codesniffer": "^3.6.1"
+        "psr/cache": "^1.0 || ^2.0 || ^3.0",
+        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
+        "squizlabs/php_codesniffer": "^3.6.2",
+        "symfony/cache-contracts": "^2.5 || ^3.0",
+        "symfony/cache": "^6.0",
+        "cache/array-adapter": "^1.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7d99351b567a6a01ca4d324da92194f6",
+    "content-hash": "595fa7e8e81b407a31cc4bfb75ab2960",
     "packages": [
         {
             "name": "amphp/amp",
@@ -243,6 +243,460 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "amphp/cache",
+            "version": "v2.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/cache.git",
+                "reference": "d2e1db2d4f2ce28384ed315dea8fbe7d0d5d9696"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/cache/zipball/d2e1db2d4f2ce28384ed315dea8fbe7d0d5d9696",
+                "reference": "d2e1db2d4f2ce28384ed315dea8fbe7d0d5d9696",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/serialization": "^1",
+                "amphp/sync": "^2",
+                "php": ">=8",
+                "revolt/event-loop": "^0.1.1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^4.15"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Cache\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                }
+            ],
+            "description": "A promise-aware caching API for Amp.",
+            "homepage": "https://github.com/amphp/cache",
+            "support": {
+                "issues": "https://github.com/amphp/cache/issues",
+                "source": "https://github.com/amphp/cache/tree/v2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-11T19:35:57+00:00"
+        },
+        {
+            "name": "amphp/serialization",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/serialization.git",
+                "reference": "693e77b2fb0b266c3c7d622317f881de44ae94a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/serialization/zipball/693e77b2fb0b266c3c7d622317f881de44ae94a1",
+                "reference": "693e77b2fb0b266c3c7d622317f881de44ae94a1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "phpunit/phpunit": "^9 || ^8 || ^7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Serialization\\": "src"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Serialization tools for IPC and data storage in PHP.",
+            "homepage": "https://github.com/amphp/serialization",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "serialization",
+                "serialize"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/serialization/issues",
+                "source": "https://github.com/amphp/serialization/tree/master"
+            },
+            "time": "2020-03-25T21:39:07+00:00"
+        },
+        {
+            "name": "amphp/sync",
+            "version": "v2.0.0-beta.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/sync.git",
+                "reference": "8933d35d03ec29f0a6ee6b29d669b2200bf2766c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/sync/zipball/8933d35d03ec29f0a6ee6b29d669b2200bf2766c",
+                "reference": "8933d35d03ec29f0a6ee6b29d669b2200bf2766c",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "php": ">=8",
+                "revolt/event-loop": "^0.1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Sync\\": "src"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Stephen Coakley",
+                    "email": "me@stephencoakley.com"
+                }
+            ],
+            "description": "Mutex, Semaphore, and other synchronization tools for Amp.",
+            "homepage": "https://github.com/amphp/sync",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "mutex",
+                "semaphore",
+                "synchronization"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/sync/issues",
+                "source": "https://github.com/amphp/sync/tree/v2.0.0-beta.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-06T01:07:02+00:00"
+        },
+        {
+            "name": "cache/adapter-common",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-cache/adapter-common.git",
+                "reference": "bbb263b04f84992cc3d524fa7f58670559d3ebf2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-cache/adapter-common/zipball/bbb263b04f84992cc3d524fa7f58670559d3ebf2",
+                "reference": "bbb263b04f84992cc3d524fa7f58670559d3ebf2",
+                "shasum": ""
+            },
+            "require": {
+                "cache/tag-interop": "^1.0",
+                "php": "^5.6 || ^7.0 || ^8.0",
+                "psr/cache": "^1.0 || ^2.0",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
+                "psr/simple-cache": "^1.0"
+            },
+            "require-dev": {
+                "cache/integration-tests": "^0.16",
+                "phpunit/phpunit": "^5.7.21"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Cache\\Adapter\\Common\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Scherer",
+                    "email": "aequasi@gmail.com",
+                    "homepage": "https://github.com/aequasi"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/nyholm"
+                }
+            ],
+            "description": "Common classes for PSR-6 adapters",
+            "homepage": "http://www.php-cache.com/en/latest/",
+            "keywords": [
+                "cache",
+                "psr-6",
+                "tag"
+            ],
+            "support": {
+                "source": "https://github.com/php-cache/adapter-common/tree/master"
+            },
+            "time": "2021-12-31T11:58:30+00:00"
+        },
+        {
+            "name": "cache/array-adapter",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-cache/array-adapter.git",
+                "reference": "e7da74c1a4921674212258b30db1a8c7eb612d9a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-cache/array-adapter/zipball/e7da74c1a4921674212258b30db1a8c7eb612d9a",
+                "reference": "e7da74c1a4921674212258b30db1a8c7eb612d9a",
+                "shasum": ""
+            },
+            "require": {
+                "cache/adapter-common": "^1.0",
+                "cache/hierarchical-cache": "^1.0",
+                "php": "^5.6 || ^7.0 || ^8.0",
+                "psr/cache": "^1.0 || ^2.0",
+                "psr/simple-cache": "^1.0"
+            },
+            "provide": {
+                "psr/cache-implementation": "^1.0",
+                "psr/simple-cache-implementation": "^1.0"
+            },
+            "require-dev": {
+                "cache/integration-tests": "^0.16",
+                "phpunit/phpunit": "^5.7.21"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Cache\\Adapter\\PHPArray\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Scherer",
+                    "email": "aequasi@gmail.com",
+                    "homepage": "https://github.com/aequasi"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/nyholm"
+                }
+            ],
+            "description": "A PSR-6 cache implementation using a php array. This implementation supports tags",
+            "homepage": "http://www.php-cache.com/en/latest/",
+            "keywords": [
+                "array",
+                "cache",
+                "psr-6",
+                "tag"
+            ],
+            "support": {
+                "source": "https://github.com/php-cache/array-adapter/tree/master"
+            },
+            "time": "2021-12-31T11:58:30+00:00"
+        },
+        {
+            "name": "cache/hierarchical-cache",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-cache/hierarchical-cache.git",
+                "reference": "dcfbbf802b3202b394f629fec2cb28c481d1e3b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-cache/hierarchical-cache/zipball/dcfbbf802b3202b394f629fec2cb28c481d1e3b6",
+                "reference": "dcfbbf802b3202b394f629fec2cb28c481d1e3b6",
+                "shasum": ""
+            },
+            "require": {
+                "cache/adapter-common": "^1.0",
+                "php": "^5.6 || ^7.0 || ^8.0",
+                "psr/cache": "^1.0 || ^2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.21"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Cache\\Hierarchy\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Scherer",
+                    "email": "aequasi@gmail.com",
+                    "homepage": "https://github.com/aequasi"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/nyholm"
+                }
+            ],
+            "description": "A helper trait and interface to your PSR-6 cache to support hierarchical keys.",
+            "homepage": "http://www.php-cache.com/en/latest/",
+            "keywords": [
+                "cache",
+                "hierarchical",
+                "hierarchy",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-cache/hierarchical-cache/tree/master"
+            },
+            "time": "2021-12-31T11:58:30+00:00"
+        },
+        {
+            "name": "cache/tag-interop",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-cache/tag-interop.git",
+                "reference": "b062b1d735357da50edf8387f7a8696f3027d328"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-cache/tag-interop/zipball/b062b1d735357da50edf8387f7a8696f3027d328",
+                "reference": "b062b1d735357da50edf8387f7a8696f3027d328",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0 || ^8.0",
+                "psr/cache": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Cache\\TagInterop\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/nyholm"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com",
+                    "homepage": "https://github.com/nicolas-grekas"
+                }
+            ],
+            "description": "Framework interoperable interfaces for tags",
+            "homepage": "https://www.php-cache.com/en/latest/",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr6",
+                "tag"
+            ],
+            "support": {
+                "issues": "https://github.com/php-cache/tag-interop/issues",
+                "source": "https://github.com/php-cache/tag-interop/tree/1.1.0"
+            },
+            "time": "2021-12-31T10:03:23+00:00"
+        },
         {
             "name": "composer/pcre",
             "version": "1.0.0",
@@ -2101,16 +2555,16 @@
         },
         {
             "name": "psr/cache",
-            "version": "3.0.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/cache.git",
-                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
+                "reference": "213f9dbc5b9bfbc4f8db86d2838dc968752ce13b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
-                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/213f9dbc5b9bfbc4f8db86d2838dc968752ce13b",
+                "reference": "213f9dbc5b9bfbc4f8db86d2838dc968752ce13b",
                 "shasum": ""
             },
             "require": {
@@ -2144,9 +2598,9 @@
                 "psr-6"
             ],
             "support": {
-                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+                "source": "https://github.com/php-fig/cache/tree/2.0.0"
             },
-            "time": "2021-02-03T23:26:27+00:00"
+            "time": "2021-02-03T23:23:37+00:00"
         },
         {
             "name": "psr/container",
@@ -2460,6 +2914,57 @@
                 "source": "https://github.com/php-fig/log/tree/2.0.0"
             },
             "time": "2021-07-14T16:41:46+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/simple-cache/tree/master"
+            },
+            "time": "2017-10-23T01:57:42+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -3524,6 +4029,178 @@
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
             "time": "2021-12-12T21:44:58+00:00"
+        },
+        {
+            "name": "symfony/cache",
+            "version": "v6.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/cache.git",
+                "reference": "41bdcb2d067c68f338b0cfd46a86abd8309b4153"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/41bdcb2d067c68f338b0cfd46a86abd8309b4153",
+                "reference": "41bdcb2d067c68f338b0cfd46a86abd8309b4153",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.2",
+                "psr/cache": "^2.0|^3.0",
+                "psr/log": "^1.1|^2|^3",
+                "symfony/cache-contracts": "^1.1.7|^2|^3",
+                "symfony/service-contracts": "^1.1|^2|^3",
+                "symfony/var-exporter": "^5.4|^6.0"
+            },
+            "conflict": {
+                "doctrine/dbal": "<2.13.1",
+                "symfony/dependency-injection": "<5.4",
+                "symfony/http-kernel": "<5.4",
+                "symfony/var-dumper": "<5.4"
+            },
+            "provide": {
+                "psr/cache-implementation": "2.0|3.0",
+                "psr/simple-cache-implementation": "1.0|2.0|3.0",
+                "symfony/cache-implementation": "1.1|2.0|3.0"
+            },
+            "require-dev": {
+                "cache/integration-tests": "dev-master",
+                "doctrine/dbal": "^2.13.1|^3.0",
+                "predis/predis": "^1.1",
+                "psr/simple-cache": "^1.0|^2.0|^3.0",
+                "symfony/config": "^5.4|^6.0",
+                "symfony/dependency-injection": "^5.4|^6.0",
+                "symfony/filesystem": "^5.4|^6.0",
+                "symfony/http-kernel": "^5.4|^6.0",
+                "symfony/messenger": "^5.4|^6.0",
+                "symfony/var-dumper": "^5.4|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Cache\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an extended PSR-6, PSR-16 (and tags) implementation",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "caching",
+                "psr6"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/cache/tree/v6.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-12-29T13:00:11+00:00"
+        },
+        {
+            "name": "symfony/cache-contracts",
+            "version": "v2.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/cache-contracts.git",
+                "reference": "ac2e168102a2e06a2624f0379bde94cd5854ced2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/ac2e168102a2e06a2624f0379bde94cd5854ced2",
+                "reference": "ac2e168102a2e06a2624f0379bde94cd5854ced2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "psr/cache": "^1.0|^2.0|^3.0"
+            },
+            "suggest": {
+                "symfony/cache-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.5-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Cache\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to caching",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/cache-contracts/tree/v2.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-08-17T14:20:01+00:00"
         },
         {
             "name": "symfony/config",
@@ -4895,6 +5572,78 @@
             "time": "2021-12-16T22:13:01+00:00"
         },
         {
+            "name": "symfony/var-exporter",
+            "version": "v6.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-exporter.git",
+                "reference": "32cf62f12d35d441da1ca4a4c0fc1cd5f2a207af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/32cf62f12d35d441da1ca4a4c0fc1cd5f2a207af",
+                "reference": "32cf62f12d35d441da1ca4a4c0fc1cd5f2a207af",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.2"
+            },
+            "require-dev": {
+                "symfony/var-dumper": "^5.4|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\VarExporter\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows exporting any serializable PHP data structure to plain PHP code",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "clone",
+                "construct",
+                "export",
+                "hydrate",
+                "instantiate",
+                "serialize"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/var-exporter/tree/v6.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-11-22T10:44:58+00:00"
+        },
+        {
             "name": "symfony/yaml",
             "version": "v6.0.2",
             "source": {
@@ -5081,7 +5830,8 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "amphp/amp": 20,
-        "azjezz/psl": 20
+        "azjezz/psl": 20,
+        "amphp/cache": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neu\Cache;
+
+use Closure;
+use Psl\Async;
+
+final class Cache implements CacheInterface
+{
+    /**
+     * @var Async\KeyedSequence<string, array{0: Closure(): mixed, 1: null|positive-int}, mixed>
+     */
+    private Async\KeyedSequence $sequence;
+
+    public function __construct(private readonly Driver\DriverInterface $driver)
+    {
+        $this->sequence = new Async\KeyedSequence(function (string $key, array $input): mixed {
+            try {
+                return $this->driver->get($key);
+            } catch (Exception\UnavailableItemException) {
+                [$computer, $ttl] = $input;
+
+                $value = $computer();
+
+                $this->driver->set($key, $value, $ttl);
+
+                return $value;
+            }
+        });
+    }
+
+    /**
+     * Gets a value associated with the given key.
+     *
+     * If the specified key doesn't exist, `$computer` will be used to compute the value.
+     *
+     * @template T
+     *
+     * @param non-empty-string $key
+     * @param Closure(): T $computer
+     * @param positive-int|null $ttl
+     *
+     * @throws Exception\InvalidKeyException If the $key string is not a legal value.
+     * @throws Exception\InvalidValueException If the value return from $computer cannot be stored in cache.
+     *
+     * @return T
+     */
+    public function compute(string $key, Closure $computer, ?int $ttl = null): mixed
+    {
+        try {
+            /** @var T */
+            return $this->driver->get($key);
+        } catch (Exception\UnavailableItemException) {
+            /** @var T */
+            return $this->sequence->waitFor($key, [$computer, $ttl]);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function delete(string $key): void
+    {
+        // wait for pending operations associated with the given key.
+        $this->sequence->waitForPending($key);
+
+        $this->driver->delete($key);
+    }
+}

--- a/src/Cache/CacheInterface.php
+++ b/src/Cache/CacheInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neu\Cache;
+
+use Closure;
+
+/**
+ * An interface that describes a cache implementation.
+ *
+ * All implementations must be atomic.
+ */
+interface CacheInterface
+{
+    /**
+     * Gets a value associated with by its unique key.
+     *
+     * If the specified key doesn't exist, `$computer` will be used to compute the value.
+     *
+     * @template T
+     *
+     * @param non-empty-string $key
+     * @param Closure(): T $computer
+     * @param positive-int|null $ttl
+     *
+     * @throws Exception\InvalidKeyException If the $key string is not a legal value.
+     * @throws Exception\InvalidValueException If the value return from $computer cannot be stored in cache.
+     *
+     * @return T
+     */
+    public function compute(string $key, Closure $computer, ?int $ttl = null): mixed;
+
+    /**
+     * Delete an item from the cache by its unique key.
+     *
+     * @param non-empty-string $key The unique cache key of the item to delete.
+     *
+     * @throws Exception\InvalidKeyException If the $key string is not a legal value.
+     */
+    public function delete(string $key): void;
+}

--- a/src/Cache/Driver/AmphpDriver.php
+++ b/src/Cache/Driver/AmphpDriver.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neu\Cache\Driver;
+
+use Amp\Cache\Cache;
+use Amp\Cache\CacheException;
+use Neu\Cache\Exception;
+use Psl\Str;
+
+final class AmphpDriver implements DriverInterface
+{
+    /**
+     * @param Cache<mixed> $cache
+     */
+    public function __construct(
+        private readonly Cache $cache,
+    ) {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function get(string $key): mixed
+    {
+        if ('' === $key) {
+            throw Exception\InvalidKeyException::forEmptyKey();
+        }
+
+        $value = $this->cache->get($key);
+        if (null === $value) {
+            throw Exception\UnavailableItemException::for($key);
+        }
+
+        return $value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function set(string $key, mixed $value, ?int $ttl = null): void
+    {
+        if ($ttl !== null && 0 >= $ttl) {
+            return;
+        }
+
+        if ('' === $key) {
+            throw Exception\InvalidKeyException::forEmptyKey();
+        }
+
+        if (null === $value) {
+            throw new Exception\InvalidValueException(Str\format('Cannot use null as a value when using "%s" driver.', self::class));
+        }
+
+        try {
+            $this->cache->set($key, $value, $ttl);
+        } catch (CacheException $e) {
+            throw new Exception\InvalidValueException($e->getMessage(), previous: $e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function delete(string $key): void
+    {
+        if ('' === $key) {
+            throw Exception\InvalidKeyException::forEmptyKey();
+        }
+
+        $this->cache->delete($key);
+    }
+}

--- a/src/Cache/Driver/DriverInterface.php
+++ b/src/Cache/Driver/DriverInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neu\Cache\Driver;
+
+use Neu\Cache\Exception;
+
+interface DriverInterface
+{
+    /**
+     * Fetches a value from the cache.
+     *
+     * @param non-empty-string $key The unique key of this item in the cache.
+     *
+     * @throws Exception\InvalidKeyException If the $key string is not a legal value.
+     * @throws Exception\UnavailableItemException If $key is not present in the cache.
+     *
+     * @return mixed The value of the item from the cache.
+     */
+    public function get(string $key): mixed;
+
+    /**
+     * Persists data in the cache, uniquely referenced by a key with an optional expiration TTL time.
+     *
+     * @param non-empty-string $key The key of the item to store.
+     * @param mixed $value The value of the item to store, must be serializable.
+     * @param null|positive-int $ttl The TTL value of this item.
+     *
+     * @throws Exception\InvalidKeyException If the $key string is not a legal value.
+     * @throws Exception\InvalidKeyException If the $value cannot be stored using this driver.
+     */
+    public function set(string $key, mixed $value, null|int $ttl = null): void;
+
+    /**
+     * Delete an item from the cache by its unique key.
+     *
+     * If the value is not present within the cache, this method *MUST* return immediately.
+     *
+     * This method must wait until the item is deleted, rather than deferring the action.
+     *
+     * @param non-empty-string $key The unique cache key of the item to delete.
+     *
+     * @throws Exception\InvalidKeyException If the $key string is not a legal value.
+     */
+    public function delete(string $key): void;
+}

--- a/src/Cache/Driver/LocalDriver.php
+++ b/src/Cache/Driver/LocalDriver.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neu\Cache\Driver;
+
+use Neu\Cache\Exception;
+use Revolt\EventLoop;
+
+use function array_key_exists;
+use function array_key_first;
+use function count;
+use function time;
+
+final class LocalDriver implements DriverInterface
+{
+    /**
+     * @var array<string, mixed>
+     */
+    private array $cache = [];
+    private array $cacheExpiration = [];
+
+    private readonly string $gcWatcher;
+
+    /**
+     * @param null|positive-int $size The maximum number of items that can be held in cache at one time.
+     * @param positive-int $gcInterval The interval of which to run garbage collection to remove expired items.
+     */
+    public function __construct(
+        private readonly ?int $size = null,
+        private readonly int $gcInterval = 10,
+    ) {
+        $this->gcWatcher = EventLoop::repeat($this->gcInterval, $this->garbageCollection(...));
+
+        EventLoop::unreference($this->gcWatcher);
+    }
+
+    public function __destruct()
+    {
+        EventLoop::disable($this->gcWatcher);
+    }
+
+    public function get(string $key): mixed
+    {
+        if ('' === $key) {
+            throw Exception\InvalidKeyException::forEmptyKey();
+        }
+
+        if (array_key_exists($key, $this->cache)) {
+            if (!array_key_exists($key, $this->cacheExpiration)) {
+                return $this->cache[$key];
+            }
+
+            if (time() < $this->cacheExpiration[$key]) {
+                return $this->cache[$key];
+            }
+
+            unset($this->cache[$key]);
+        }
+
+        throw Exception\UnavailableItemException::for($key);
+    }
+
+    public function set(string $key, mixed $value, ?int $ttl = null): void
+    {
+        if ($ttl !== null && 0 >= $ttl) {
+            return;
+        }
+
+        if ('' === $key) {
+            throw Exception\InvalidKeyException::forEmptyKey();
+        }
+
+        $this->cache[$key] = $value;
+        if ($ttl !== null) {
+            $this->cacheExpiration[$key] = time() + $ttl;
+        }
+
+        if (null !== $this->size && count($this->cache) === $this->size) {
+            $this->delete(array_key_first($this->cache));
+        }
+    }
+
+    public function delete(string $key): void
+    {
+        if ('' === $key) {
+            throw Exception\InvalidKeyException::forEmptyKey();
+        }
+
+        unset($this->cache[$key], $this->cacheExpiration[$key]);
+    }
+
+    private function garbageCollection(): void
+    {
+        foreach ($this->cacheExpiration as $key => $time) {
+            if (time() >= $time) {
+                $this->delete($key);
+            }
+        }
+    }
+}

--- a/src/Cache/Driver/Psr16Driver.php
+++ b/src/Cache/Driver/Psr16Driver.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neu\Cache\Driver;
+
+use Neu\Cache\Exception;
+use Psr\SimpleCache\CacheInterface;
+use Psr\SimpleCache\InvalidArgumentException;
+
+final class Psr16Driver implements DriverInterface
+{
+    public function __construct(
+        private readonly CacheInterface $cache
+    ) {
+    }
+
+    public function get(string $key): mixed
+    {
+        if ('' === $key) {
+            throw Exception\InvalidKeyException::forEmptyKey();
+        }
+
+        try {
+            if (!$this->cache->has($key)) {
+                throw Exception\UnavailableItemException::for($key);
+            }
+
+            return $this->cache->get($key);
+        } catch (InvalidArgumentException $e) {
+            throw new Exception\InvalidKeyException($e->getMessage(), previous: $e);
+        }
+    }
+
+    public function set(string $key, mixed $value, ?int $ttl = null): void
+    {
+        if ($ttl !== null && 0 >= $ttl) {
+            return;
+        }
+
+        if ('' === $key) {
+            throw Exception\InvalidKeyException::forEmptyKey();
+        }
+
+        try {
+            $this->cache->set($key, $value, $ttl);
+        } catch (InvalidArgumentException $e) {
+            throw new Exception\InvalidKeyException($e->getMessage(), previous: $e);
+        }
+    }
+
+    public function delete(string $key): void
+    {
+        if ('' === $key) {
+            throw Exception\InvalidKeyException::forEmptyKey();
+        }
+
+        try {
+            $this->cache->delete($key);
+        } catch (InvalidArgumentException $e) {
+            throw new Exception\InvalidKeyException($e->getMessage(), previous: $e);
+        }
+    }
+}

--- a/src/Cache/Driver/Psr6Driver.php
+++ b/src/Cache/Driver/Psr6Driver.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neu\Cache\Driver;
+
+use Neu\Cache\Exception;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Cache\InvalidArgumentException;
+
+final class Psr6Driver implements DriverInterface
+{
+    public function __construct(
+        private readonly CacheItemPoolInterface $pool
+    ) {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function get(string $key): mixed
+    {
+        if ('' === $key) {
+            throw Exception\InvalidKeyException::forEmptyKey();
+        }
+
+        try {
+            $item = $this->pool->getItem($key);
+        } catch (InvalidArgumentException $e) {
+            throw new Exception\InvalidKeyException($e->getMessage(), previous: $e);
+        }
+
+        if (!$item->isHit()) {
+            throw Exception\UnavailableItemException::for($key);
+        }
+
+        return $item->get();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function set(string $key, mixed $value, ?int $ttl = null): void
+    {
+        if ($ttl !== null && 0 >= $ttl) {
+            return;
+        }
+
+        if ('' === $key) {
+            throw Exception\InvalidKeyException::forEmptyKey();
+        }
+
+        try {
+            $item = $this->pool->getItem($key);
+        } catch (InvalidArgumentException $e) {
+            throw new Exception\InvalidKeyException($e->getMessage(), previous: $e);
+        }
+
+        $item->set($value);
+        $item->expiresAfter($ttl);
+
+        $this->pool->save($item);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function delete(string $key): void
+    {
+        if ('' === $key) {
+            throw Exception\InvalidKeyException::forEmptyKey();
+        }
+
+        try {
+            $this->pool->deleteItem($key);
+        } catch (InvalidArgumentException $e) {
+            throw new Exception\InvalidKeyException($e->getMessage(), previous: $e);
+        }
+    }
+}

--- a/src/Cache/Driver/SymfonyDriver.php
+++ b/src/Cache/Driver/SymfonyDriver.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neu\Cache\Driver;
+
+use Neu\Cache\Exception;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\InvalidArgumentException;
+use Symfony\Contracts\Cache\CacheInterface;
+
+use const INF;
+
+final class SymfonyDriver implements DriverInterface
+{
+    public function __construct(private readonly CacheInterface $cache)
+    {
+    }
+
+    public function get(string $key): mixed
+    {
+        if ('' === $key) {
+            throw Exception\InvalidKeyException::forEmptyKey();
+        }
+
+        try {
+            return $this->cache->get($key, static function () use ($key) {
+                throw Exception\UnavailableItemException::for($key);
+            });
+        } catch (InvalidArgumentException $e) {
+            throw new Exception\InvalidKeyException($e->getMessage(), previous: $e);
+        }
+    }
+
+    public function set(string $key, mixed $value, ?int $ttl = null): void
+    {
+        if ($ttl !== null && 0 >= $ttl) {
+            return;
+        }
+
+        if ('' === $key) {
+            throw Exception\InvalidKeyException::forEmptyKey();
+        }
+
+        try {
+            $this->cache->get($key, static function (CacheItemInterface $item) use ($value, $ttl) {
+                $item->expiresAfter($ttl);
+
+                return $value;
+            }, INF);
+        } catch (InvalidArgumentException $e) {
+            throw new Exception\InvalidKeyException($e->getMessage(), previous: $e);
+        }
+    }
+
+    public function delete(string $key): void
+    {
+        if ('' === $key) {
+            throw Exception\InvalidKeyException::forEmptyKey();
+        }
+
+        try {
+            $this->cache->delete($key);
+        } catch (InvalidArgumentException $e) {
+            throw new Exception\InvalidKeyException($e->getMessage(), previous: $e);
+        }
+    }
+}

--- a/src/Cache/Exception/ExceptionInterface.php
+++ b/src/Cache/Exception/ExceptionInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neu\Cache\Exception;
+
+use Throwable;
+
+interface ExceptionInterface extends Throwable
+{
+}

--- a/src/Cache/Exception/InvalidKeyException.php
+++ b/src/Cache/Exception/InvalidKeyException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neu\Cache\Exception;
+
+use InvalidArgumentException;
+
+final class InvalidKeyException extends InvalidArgumentException implements ExceptionInterface
+{
+    public static function forEmptyKey(): self
+    {
+        return new self('Cache key must not be empty.');
+    }
+}

--- a/src/Cache/Exception/InvalidValueException.php
+++ b/src/Cache/Exception/InvalidValueException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neu\Cache\Exception;
+
+use InvalidArgumentException;
+
+final class InvalidValueException extends InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/src/Cache/Exception/UnavailableItemException.php
+++ b/src/Cache/Exception/UnavailableItemException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neu\Cache\Exception;
+
+use Psl\Str;
+use RuntimeException;
+
+final class UnavailableItemException extends RuntimeException implements ExceptionInterface
+{
+    /**
+     * Create an {@see UnavailableItemException} for the given key.
+     *
+     * @param non-empty-string $key
+     */
+    public static function for(string $key): self
+    {
+        return new self(Str\format('No cache item is associated with the "%s" key.', $key));
+    }
+}

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neu\Tests\Cache;
+
+use Amp\Cache\LocalCache;
+use Cache\Adapter\PHPArray\ArrayCachePool;
+use Neu\Cache;
+use PHPUnit\Framework\TestCase;
+use Psl;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Psr16Cache;
+
+final class CacheTest extends TestCase
+{
+    /**
+     * @return iterable<array{0: Cache\Cache, 1: Cache\Driver\DriverInterface}>
+     */
+    public function provideCache(): iterable
+    {
+        $driver = new Cache\Driver\LocalDriver(100, 5);
+        yield [new Cache\Cache($driver), $driver];
+
+        $driver = new Cache\Driver\Psr6Driver(new ArrayAdapter());
+        yield [new Cache\Cache($driver), $driver];
+
+        $driver = new Cache\Driver\Psr16Driver(new Psr16Cache(new ArrayAdapter()));
+        yield [new Cache\Cache($driver), $driver];
+
+        $driver = new Cache\Driver\Psr16Driver(new ArrayCachePool());
+        yield [new Cache\Cache($driver), $driver];
+
+        $driver = new Cache\Driver\AmphpDriver(new LocalCache());
+        yield [new Cache\Cache($driver), $driver];
+
+        $driver = new Cache\Driver\SymfonyDriver(new ArrayAdapter());
+        yield [new Cache\Cache($driver), $driver];
+    }
+
+    /**
+     * @dataProvider provideCache
+     */
+    public function testAtomic(Cache\Cache $cache, Cache\Driver\DriverInterface $driver): void
+    {
+        $ref = new Psl\Ref(false);
+        $computer = static function () use ($ref): string {
+            $ref->value = true;
+            Psl\Async\sleep(0.02);
+
+            return 'azjezz';
+        };
+
+        $user = $cache->compute('user', $computer, ttl: 1);
+        static::assertSame('azjezz', $user);
+        static::assertTrue($ref->value);
+
+        $ref->value = false;
+        $user = $cache->compute('user', $computer, ttl: 1);
+        static::assertSame('azjezz', $user);
+        static::assertFalse($ref->value);
+
+        $driver->delete('user');
+
+        $user = $cache->compute('user', $computer, ttl: 1);
+        static::assertSame('azjezz', $user);
+        static::assertTrue($ref->value);
+        $ref->value = false;
+        $cache->delete('user');
+
+        $ref = new Psl\Ref('a');
+        Psl\Async\Scheduler::defer(static function () use ($cache, $computer, $ref): void {
+            // compute the item again.
+            $user = $cache->compute('user', $computer, ttl: 1);
+            self::assertSame('azjezz', $user);
+            self::assertSame('b', $ref->value);
+            $ref->value = 'c';
+        });
+
+        Psl\Async\later();
+
+        static::assertSame('a', $ref->value);
+        $ref->value = 'b';
+        $cache->delete('user'); // will wait until defer is finished.
+        static::assertSame('c', $ref->value);
+    }
+
+    /**
+     * @dataProvider provideCache
+     */
+    public function testDelete(Cache\Cache $cache, Cache\Driver\DriverInterface $driver): void
+    {
+        $cache->compute('user', function (): string {
+            $this->addToAssertionCount(1);
+
+            return 'azjezz';
+        });
+
+        $user = $cache->compute('user', static function (): string {
+            self::fail('value should been in cache.');
+        });
+
+        static::assertSame('azjezz', $driver->get('user'));
+        static::assertSame('azjezz', $user);
+
+        $cache->delete('user');
+
+        $this->expectException(Cache\Exception\UnavailableItemException::class);
+        $this->expectExceptionMessage('No cache item is associated with the "user" key.');
+
+        $driver->get('user');
+    }
+}

--- a/tests/Cache/Driver/AmphpDriverTest.php
+++ b/tests/Cache/Driver/AmphpDriverTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neu\Tests\Cache\Driver;
+
+use Amp\Cache\LocalCache;
+use Neu\Cache;
+use PHPUnit\Framework\TestCase;
+
+final class AmphpDriverTest extends TestCase
+{
+    public function testInvalidKey(): void
+    {
+        $driver = new Cache\Driver\AmphpDriver(new LocalCache());
+
+        try {
+            $driver->set('', 'foo');
+            static::fail('Expected exception to be thrown');
+        } catch (Cache\Exception\InvalidKeyException $e) {
+            $this->addToAssertionCount(1);
+            static::assertSame('Cache key must not be empty.', $e->getMessage());
+        }
+
+        try {
+            $driver->get('');
+            static::fail('Expected exception to be thrown');
+        } catch (Cache\Exception\InvalidKeyException) {
+            $this->addToAssertionCount(1);
+        }
+
+        try {
+            $driver->delete('');
+            static::fail('Expected exception to be thrown');
+        } catch (Cache\Exception\InvalidKeyException) {
+            $this->addToAssertionCount(1);
+        }
+    }
+
+    public function testSetGetDelete(): void
+    {
+        $driver = new Cache\Driver\AmphpDriver(new LocalCache());
+
+        $driver->set('user', 'azjezz');
+        static::assertSame('azjezz', $driver->get('user'));
+        $driver->set('user', 'trowski');
+        static::assertSame('trowski', $driver->get('user'));
+        $driver->delete('user');
+
+        try {
+            $driver->get('user');
+            static::fail('Expected exception to be thrown.');
+        } catch (Cache\Exception\UnavailableItemException) {
+            $this->addToAssertionCount(1);
+        }
+
+        $driver->set('user', 'azjezz', 0);
+        $this->expectException(Cache\Exception\UnavailableItemException::class);
+        $driver->get('user');
+    }
+}

--- a/tests/Cache/Driver/LocalDriverTest.php
+++ b/tests/Cache/Driver/LocalDriverTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neu\Tests\Cache\Driver;
+
+use Neu\Cache;
+use PHPUnit\Framework\TestCase;
+
+final class LocalDriverTest extends TestCase
+{
+    public function testInvalidKey(): void
+    {
+        $driver = new Cache\Driver\LocalDriver();
+
+        try {
+            $driver->set('', 'foo');
+            static::fail('Expected exception to be thrown');
+        } catch (Cache\Exception\InvalidKeyException $e) {
+            $this->addToAssertionCount(1);
+            static::assertSame('Cache key must not be empty.', $e->getMessage());
+        }
+
+        try {
+            $driver->get('');
+            static::fail('Expected exception to be thrown');
+        } catch (Cache\Exception\InvalidKeyException) {
+            $this->addToAssertionCount(1);
+        }
+
+        try {
+            $driver->delete('');
+            static::fail('Expected exception to be thrown');
+        } catch (Cache\Exception\InvalidKeyException) {
+            $this->addToAssertionCount(1);
+        }
+    }
+
+    public function testSetGetDelete(): void
+    {
+        $driver = new Cache\Driver\LocalDriver();
+
+        $driver->set('user', 'azjezz');
+        static::assertSame('azjezz', $driver->get('user'));
+        $driver->set('user', 'trowski');
+        static::assertSame('trowski', $driver->get('user'));
+        $driver->delete('user');
+
+        try {
+            $driver->get('user');
+            static::fail('Expected exception to be thrown.');
+        } catch (Cache\Exception\UnavailableItemException) {
+            $this->addToAssertionCount(1);
+        }
+
+        $driver->set('user', 'azjezz', 0);
+        $this->expectException(Cache\Exception\UnavailableItemException::class);
+        $driver->get('user');
+    }
+
+    public function testSizeLimit(): void
+    {
+        $driver = new Cache\Driver\LocalDriver(size: 2);
+
+        $driver->set('foo', 'value');
+        static::assertSame('value', $driver->get('foo'));
+        $driver->set('bar', 'value');
+        static::assertSame('value', $driver->get('bar'));
+        $driver->set('baz', 'value');
+        static::assertSame('value', $driver->get('baz'));
+
+        $this->expectException(Cache\Exception\UnavailableItemException::class);
+
+        $driver->get('foo');
+    }
+}

--- a/tests/Cache/Driver/Psr16DriverTest.php
+++ b/tests/Cache/Driver/Psr16DriverTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neu\Tests\Cache\Driver;
+
+use Cache\Adapter\PHPArray\ArrayCachePool;
+use Neu\Cache;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Psr16Cache;
+
+final class Psr16DriverTest extends TestCase
+{
+    public function testInvalidKey(): void
+    {
+        $driver = new Cache\Driver\Psr16Driver(new ArrayCachePool());
+        try {
+            $driver->set('', 'foo');
+            static::fail('Expected exception to be thrown');
+        } catch (Cache\Exception\InvalidKeyException $e) {
+            $this->addToAssertionCount(1);
+            static::assertSame('Cache key must not be empty.', $e->getMessage());
+        }
+
+        try {
+            $driver->get('');
+            static::fail('Expected exception to be thrown');
+        } catch (Cache\Exception\InvalidKeyException) {
+            $this->addToAssertionCount(1);
+        }
+
+        try {
+            $driver->delete('');
+            static::fail('Expected exception to be thrown');
+        } catch (Cache\Exception\InvalidKeyException) {
+            $this->addToAssertionCount(1);
+        }
+
+        $this->expectException(Cache\Exception\InvalidKeyException::class);
+
+        $driver->get('{framework}');
+    }
+
+    public function testSetGetDelete(): void
+    {
+        $driver = new Cache\Driver\Psr16Driver(new Psr16Cache(new ArrayAdapter()));
+
+        $driver->set('user', 'azjezz');
+        static::assertSame('azjezz', $driver->get('user'));
+        $driver->set('user', 'trowski');
+        static::assertSame('trowski', $driver->get('user'));
+        $driver->delete('user');
+
+        try {
+            $driver->get('user');
+            static::fail('Expected exception to be thrown.');
+        } catch (Cache\Exception\UnavailableItemException) {
+            $this->addToAssertionCount(1);
+        }
+
+        $driver->set('user', 'azjezz', 0);
+        $this->expectException(Cache\Exception\UnavailableItemException::class);
+        $driver->get('user');
+    }
+}

--- a/tests/Cache/Driver/Psr6DriverTest.php
+++ b/tests/Cache/Driver/Psr6DriverTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neu\Tests\Cache\Driver;
+
+use Cache\Adapter\PHPArray\ArrayCachePool;
+use Neu\Cache;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+final class Psr6DriverTest extends TestCase
+{
+    public function testInvalidKey(): void
+    {
+        $driver = new Cache\Driver\Psr6Driver(new ArrayCachePool());
+        try {
+            $driver->set('', 'foo');
+            static::fail('Expected exception to be thrown');
+        } catch (Cache\Exception\InvalidKeyException $e) {
+            $this->addToAssertionCount(1);
+            static::assertSame('Cache key must not be empty.', $e->getMessage());
+        }
+
+        try {
+            $driver->get('');
+            static::fail('Expected exception to be thrown');
+        } catch (Cache\Exception\InvalidKeyException) {
+            $this->addToAssertionCount(1);
+        }
+
+        try {
+            $driver->delete('');
+            static::fail('Expected exception to be thrown');
+        } catch (Cache\Exception\InvalidKeyException) {
+            $this->addToAssertionCount(1);
+        }
+
+        $this->expectException(Cache\Exception\InvalidKeyException::class);
+
+        $driver->set('{framework}', 'foo');
+    }
+
+    public function testSetGetDelete(): void
+    {
+        $driver = new Cache\Driver\Psr6Driver(new ArrayAdapter());
+
+        $driver->set('user', 'azjezz');
+        static::assertSame('azjezz', $driver->get('user'));
+        $driver->set('user', 'trowski');
+        static::assertSame('trowski', $driver->get('user'));
+        $driver->delete('user');
+
+        try {
+            $driver->get('user');
+            static::fail('Expected exception to be thrown.');
+        } catch (Cache\Exception\UnavailableItemException) {
+            $this->addToAssertionCount(1);
+        }
+
+        $driver->set('user', 'azjezz', 0);
+        $this->expectException(Cache\Exception\UnavailableItemException::class);
+        $driver->get('user');
+    }
+}

--- a/tests/Cache/Driver/SymfonyDriverTest.php
+++ b/tests/Cache/Driver/SymfonyDriverTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neu\Tests\Cache\Driver;
+
+use Cache\Adapter\PHPArray\ArrayCachePool;
+use Neu\Cache;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\ProxyAdapter;
+
+final class SymfonyDriverTest extends TestCase
+{
+    public function testInvalidKey(): void
+    {
+        $driver = new Cache\Driver\SymfonyDriver(new ProxyAdapter(new ArrayCachePool()));
+        try {
+            $driver->set('', 'foo');
+            static::fail('Expected exception to be thrown');
+        } catch (Cache\Exception\InvalidKeyException $e) {
+            $this->addToAssertionCount(1);
+            static::assertSame('Cache key must not be empty.', $e->getMessage());
+        }
+
+        try {
+            $driver->get('');
+            static::fail('Expected exception to be thrown');
+        } catch (Cache\Exception\InvalidKeyException) {
+            $this->addToAssertionCount(1);
+        }
+
+        try {
+            $driver->delete('');
+            static::fail('Expected exception to be thrown');
+        } catch (Cache\Exception\InvalidKeyException) {
+            $this->addToAssertionCount(1);
+        }
+
+        $this->expectException(Cache\Exception\InvalidKeyException::class);
+
+        $driver->delete('{framework}');
+    }
+
+    public function testSetGetDelete(): void
+    {
+        $driver = new Cache\Driver\SymfonyDriver(new ArrayAdapter());
+
+        $driver->set('user', 'azjezz');
+        static::assertSame('azjezz', $driver->get('user'));
+        $driver->set('user', 'trowski');
+        static::assertSame('trowski', $driver->get('user'));
+        $driver->delete('user');
+
+        try {
+            $driver->get('user');
+            static::fail('Expected exception to be thrown.');
+        } catch (Cache\Exception\UnavailableItemException) {
+            $this->addToAssertionCount(1);
+        }
+
+        $driver->set('user', 'azjezz', 0);
+        $this->expectException(Cache\Exception\UnavailableItemException::class);
+        $driver->get('user');
+    }
+}


### PR DESCRIPTION
Neu cache provides an atomic cache implementation, with multiple drivers allowing you to convert any existing PSR-6, PSR-16, Amphp, and Symfony cache object into a simple atomic cache.

---

TODO:

- [x] add tests
- [x] ~introduce redis driver based on amphp/redis~ not needed, amphp/redis provides amphp/cache implementation that could be used with the AmphpDriver
- [x] ~introduce filesystem driver based on amphp/file~ for another PR.
- [x] ~introduce mysql/pgsql drivers based on amphp/mysql and amphp/postgresql~ for another PR.

